### PR TITLE
Support big batches in createOrders()

### DIFF
--- a/src/Endpoints/Orders.php
+++ b/src/Endpoints/Orders.php
@@ -100,7 +100,7 @@ class Orders extends BaseEndpoint
     public function createOrders($orders = [])
     {
         $orders = array_map(function($order) {
-            array_filter($order->toArray());
+            return array_filter($order->toArray());
         }, $orders);
 
         return $this->post('createorders', [

--- a/src/Endpoints/Orders.php
+++ b/src/Endpoints/Orders.php
@@ -99,8 +99,12 @@ class Orders extends BaseEndpoint
      */
     public function createOrders($orders = [])
     {
+        $orders = array_map(function($order) {
+            array_filter($order->toArray());
+        }, $orders);
+
         return $this->post('createorders', [
-            'form_params' => $orders->toArray()
+            'json' => $orders
         ]);
     }
 


### PR DESCRIPTION
Use the json argument instead of form_params, and remove any null elements before POSTing, as the API will complain otherwise.